### PR TITLE
Use | instead of + when building a flash address.

### DIFF
--- a/timonel-bootloader/timonel.c
+++ b/timonel-bootloader/timonel.c
@@ -487,7 +487,7 @@ inline void Reply_DELFLASH(MemPack *p_mem_pack) {
 */
 inline void Reply_STPGADDR(const uint8_t *command, MemPack *p_mem_pack) {
     uint8_t reply[STPGADDR_RPLYLN] = {0};
-    p_mem_pack->page_addr = ((command[1] << 8) + command[2]);  // Sets the flash memory page base address
+    p_mem_pack->page_addr = ((command[1] << 8) | command[2]);  // Sets the flash memory page base address
     p_mem_pack->page_addr &= ~(SPM_PAGESIZE - 1);              // Keep only pages' base addresses
     reply[0] = AKPGADDR;
     reply[1] = (uint8_t)(command[1] + command[2]);  // Returns the sum of MSB and LSB of the page address
@@ -556,7 +556,7 @@ inline void Reply_READFLSH(const uint8_t *command) {
     // Point the initial memory position to the received address, then
     // advance to fill the reply with the requested data amount.
     const __flash uint8_t *mem_position;
-    mem_position = (void *)((command[1] << 8) + command[2]);
+    mem_position = (void *)((command[1] << 8) | command[2]);
     for (uint8_t i = 1; i < command[3] + 1; i++) {
         reply[i] = (*(mem_position++) & 0xFF);        // Actual memory position data
         reply[reply_len - 1] += (uint8_t)(reply[i]);  // Checksum accumulator
@@ -614,7 +614,7 @@ inline void Reply_READDEVS(void) {
 */
 inline void Reply_WRITEEPR(const uint8_t *command) {
     uint8_t reply[WRITEEPR_RPLYLN] = {0};
-    uint16_t eeprom_addr = ((command[1] << 8) + command[2]);    // Set the EEPROM address
+    uint16_t eeprom_addr = ((command[1] << 8) | command[2]);    // Set the EEPROM address
     eeprom_addr &= E2END;                                       // Keep only valid EEPROM addresses
     reply[0] = ACKWTEEP;
     reply[1] = (uint8_t)(command[1] + command[2] + command[3]); // Returns the sum of EEPROM address MSB, LSB and data byte
@@ -631,7 +631,7 @@ inline void Reply_WRITEEPR(const uint8_t *command) {
 */
 inline void Reply_READEEPR(const uint8_t *command) {
     uint8_t reply[READEEPR_RPLYLN] = {0};
-    uint16_t eeprom_addr = ((command[1] << 8) + command[2]);    // Set the EEPROM address
+    uint16_t eeprom_addr = ((command[1] << 8) | command[2]);    // Set the EEPROM address
     eeprom_addr &= E2END;                                       // Keep only valid EEPROM addresses
     reply[0] = ACKRDEEP;
     reply[1] = (uint8_t)eeprom_read_byte((uint8_t *)eeprom_addr);


### PR DESCRIPTION
Use | instead of + when building a 16-bit address from 2 bytes in the message buffer. 
This is safe, since addition cannot overflow, and consistent with other places in the code where it was already done using |
Each change saves 4 bytes (tml-t85-test-comm is 16 bytes shorter)
The commit does _not_ rebuild the distribution .hex files.
Tested informally with READEEPR and WRITEEPR only